### PR TITLE
CRT static: Use flag instead of .config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -183,11 +183,13 @@ fn main() {
             println!("cargo:rustc-link-lib=dylib=dxgi");
             println!("cargo:rustc-link-lib=dylib=dwmapi");
             println!("cargo:rustc-link-lib=static=webrtc");
+            println!("cargo:rustc-link-arg=/NODEFAULTLIB:libcmt");
 
             builder
                 .flag("/std:c++17")
                 .flag("/EHsc")
                 .static_crt(true)
+                .no_default_flags(true)
                 .define("WEBRTC_WIN", None)
                 //.define("WEBRTC_ENABLE_SYMBOL_EXPORT", None) Not necessary when using WebRTC as a static library
                 .define("NOMINMAX", None);

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -187,6 +187,7 @@ fn main() {
             builder
                 .flag("/std:c++17")
                 .flag("/EHsc")
+                .static_crt(true)
                 .define("WEBRTC_WIN", None)
                 //.define("WEBRTC_ENABLE_SYMBOL_EXPORT", None) Not necessary when using WebRTC as a static library
                 .define("NOMINMAX", None);


### PR DESCRIPTION
Don't force the user to use +crt-static inside .config 